### PR TITLE
Add basic Jekyll configuration and project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Streamcode9 Blog
+
+This repository hosts a simple Jekyll-based site for experiments and notes.
+
+## Project goals
+- Share code snippets, blog posts, and musical riffs.
+- Serve as personal notes and experiments.
+
+## Build steps
+1. Install Ruby and Jekyll (`gem install bundler jekyll`).
+2. Build the site locally with `jekyll serve`.
+
+## Deployment
+Pushing to the `main` branch builds and deploys the site via GitHub Pages.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+title: Streamcode9 Blog
+description: A space for sharing code experiments and musical riffs.
+theme: minima


### PR DESCRIPTION
## Summary
- add Jekyll `_config.yml` with site title, description, and theme
- document goals, build steps, and deployment in `README.md`

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689906942ff0833290c1f40d882864c6