### PR TITLE
Fix WASI SDK download extraction

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -1,0 +1,38 @@
+name: Build WebAssembly Hello World
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download wasi-sdk
+        run: |
+          WASI_VERSION=20.0
+          WASI_RELEASE="wasi-sdk-${WASI_VERSION}"
+          WASI_PACKAGE="${WASI_RELEASE}-linux.tar.xz"
+          curl -L "https://github.com/WebAssembly/wasi-sdk/releases/download/${WASI_RELEASE}/${WASI_PACKAGE}" -o wasi-sdk.tar.xz
+          tar -xJf wasi-sdk.tar.xz
+          mv "${WASI_RELEASE}" wasi-sdk
+
+      - name: Compile C89 hello world to WebAssembly
+        run: |
+          ./wasi-sdk/bin/clang \
+            --sysroot=./wasi-sdk/share/wasi-sysroot \
+            -std=c89 \
+            wasm/hello.c \
+            -o wasm/hello.wasm
+
+      - name: Upload WebAssembly artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hello-wasm
+          path: wasm/hello.wasm

--- a/wasm/hello.c
+++ b/wasm/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(void)
+{
+    printf("Hello, world!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- update the workflow to fetch the .tar.xz wasi-sdk archive
- extract the archive with the correct tar flags to avoid gzip errors during CI

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfdc55f0d88332adb75a81eb9a1f43