### PR TITLE
Fix WASI SDK download asset

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -16,12 +16,13 @@ jobs:
 
       - name: Download wasi-sdk
         run: |
-          WASI_VERSION=20.0
-          WASI_RELEASE="wasi-sdk-${WASI_VERSION}"
-          WASI_PACKAGE="${WASI_RELEASE}-linux.tar.xz"
-          curl -L "https://github.com/WebAssembly/wasi-sdk/releases/download/${WASI_RELEASE}/${WASI_PACKAGE}" -o wasi-sdk.tar.xz
-          tar -xJf wasi-sdk.tar.xz
-          mv "${WASI_RELEASE}" wasi-sdk
+          WASI_TAG_VERSION=20
+          WASI_ASSET_VERSION="${WASI_TAG_VERSION}.0"
+          WASI_RELEASE="wasi-sdk-${WASI_TAG_VERSION}"
+          WASI_PACKAGE="wasi-sdk-${WASI_ASSET_VERSION}-linux.tar.gz"
+          curl -L "https://github.com/WebAssembly/wasi-sdk/releases/download/${WASI_RELEASE}/${WASI_PACKAGE}" -o wasi-sdk.tar.gz
+          tar -xzf wasi-sdk.tar.gz
+          mv "wasi-sdk-${WASI_ASSET_VERSION}" wasi-sdk
 
       - name: Compile C89 hello world to WebAssembly
         run: |


### PR DESCRIPTION
## Summary
- adjust the WASI SDK download to use the correct release tag and asset archive
- update the extraction command to handle the .tar.gz package format

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d0265be9808332a7976fb67e564eb4