### PR TITLE
Add main entry point to standalone wasm module

### DIFF
--- a/wasm/hello.c
+++ b/wasm/hello.c
@@ -14,3 +14,8 @@ size_t get_greeting_length(void)
 {
     return sizeof(GREETING) - 1;
 }
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a minimal `main` function so the standalone WebAssembly build has the required entry point

## Testing
- not run (emcc is not available in the local environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0556b83b8833285390af33b131bdc