### PR TITLE
Add WASM bouncing ball demo

### DIFF
--- a/wasm/game.js
+++ b/wasm/game.js
@@ -1,0 +1,61 @@
+const canvas = document.getElementById('game-canvas');
+const context = canvas.getContext('2d');
+let wasmExports = null;
+let lastTime = null;
+
+function resizeCanvas() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+
+  if (wasmExports) {
+    wasmExports.set_canvas_size(canvas.width, canvas.height);
+  }
+}
+
+function drawFrame() {
+  if (!wasmExports) {
+    return;
+  }
+
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  context.fillStyle = '#0d47a1';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  const radius = wasmExports.get_ball_radius();
+  const x = wasmExports.get_ball_x();
+  const y = wasmExports.get_ball_y();
+
+  context.fillStyle = '#ffca28';
+  context.beginPath();
+  context.arc(x, y, radius, 0, Math.PI * 2);
+  context.fill();
+}
+
+function updateAndRender(timestamp) {
+  if (!lastTime) {
+    lastTime = timestamp;
+  }
+
+  const deltaSeconds = (timestamp - lastTime) / 1000;
+  lastTime = timestamp;
+
+  wasmExports.update(deltaSeconds);
+  drawFrame();
+
+  requestAnimationFrame(updateAndRender);
+}
+
+async function start() {
+  const response = await fetch('hello.wasm');
+  const bytes = await response.arrayBuffer();
+  const { instance } = await WebAssembly.instantiate(bytes, {});
+  wasmExports = instance.exports;
+
+  resizeCanvas();
+  wasmExports.reset_ball();
+  drawFrame();
+  requestAnimationFrame(updateAndRender);
+}
+
+window.addEventListener('resize', resizeCanvas);
+start();

--- a/wasm/hello.c
+++ b/wasm/hello.c
@@ -1,16 +1,93 @@
-#include <stddef.h>
 #include <emscripten/emscripten.h>
 
-static const char GREETING[] = "Hello from WebAssembly!";
+static float canvas_width = 640.0f;
+static float canvas_height = 480.0f;
+static float ball_x = 320.0f;
+static float ball_y = 240.0f;
+static float ball_radius = 16.0f;
+static float velocity_x = 180.0f;
+static float velocity_y = 140.0f;
 
-EMSCRIPTEN_KEEPALIVE
-const char *get_greeting(void)
+static void clamp_ball_inside_canvas(void)
 {
-    return GREETING;
+    if (ball_x < ball_radius) {
+        ball_x = ball_radius;
+    } else if (ball_x > canvas_width - ball_radius) {
+        ball_x = canvas_width - ball_radius;
+    }
+
+    if (ball_y < ball_radius) {
+        ball_y = ball_radius;
+    } else if (ball_y > canvas_height - ball_radius) {
+        ball_y = canvas_height - ball_radius;
+    }
 }
 
 EMSCRIPTEN_KEEPALIVE
-size_t get_greeting_length(void)
+void set_canvas_size(int width, int height)
 {
-    return sizeof(GREETING) - 1;
+    if (width > 0) {
+        canvas_width = (float)width;
+    }
+
+    if (height > 0) {
+        canvas_height = (float)height;
+    }
+
+    clamp_ball_inside_canvas();
+}
+
+EMSCRIPTEN_KEEPALIVE
+void reset_ball(void)
+{
+    ball_x = canvas_width * 0.5f;
+    ball_y = canvas_height * 0.5f;
+    velocity_x = 180.0f;
+    velocity_y = 140.0f;
+    clamp_ball_inside_canvas();
+}
+
+EMSCRIPTEN_KEEPALIVE
+void update(float delta_seconds)
+{
+    if (delta_seconds <= 0.0f) {
+        return;
+    }
+
+    ball_x += velocity_x * delta_seconds;
+    ball_y += velocity_y * delta_seconds;
+
+    if (ball_x - ball_radius < 0.0f) {
+        ball_x = ball_radius;
+        velocity_x = -velocity_x;
+    } else if (ball_x + ball_radius > canvas_width) {
+        ball_x = canvas_width - ball_radius;
+        velocity_x = -velocity_x;
+    }
+
+    if (ball_y - ball_radius < 0.0f) {
+        ball_y = ball_radius;
+        velocity_y = -velocity_y;
+    } else if (ball_y + ball_radius > canvas_height) {
+        ball_y = canvas_height - ball_radius;
+        velocity_y = -velocity_y;
+    }
+}
+
+EMSCRIPTEN_KEEPALIVE
+float get_ball_x(void)
+{
+    return ball_x;
+}
+
+EMSCRIPTEN_KEEPALIVE
+float get_ball_y(void)
+{
+    return ball_y;
+}
+
+EMSCRIPTEN_KEEPALIVE
+float get_ball_radius(void)
+{
+    return ball_radius;
 }

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Minimal WASM Bouncing Ball</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #111827;
+        color: #f9fafb;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+      }
+
+      h1 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin: 1rem 0 0.5rem;
+      }
+
+      p {
+        margin: 0 1.5rem 1.5rem;
+        max-width: 32rem;
+        text-align: center;
+        line-height: 1.5;
+      }
+
+      canvas {
+        flex: 1;
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>WebAssembly Bouncing Ball Demo</h1>
+    <p>The ball is simulated inside WebAssembly and rendered on an HTML canvas.</p>
+    <canvas id="game-canvas"></canvas>
+    <script type="module" src="game.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the previous greeting sample with a WebAssembly-powered bouncing ball simulation
- add a lightweight JavaScript loop that loads the module, updates the physics, and renders to canvas
- provide a minimal HTML host page for the demo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d313ccc8288332852f4d1a59f24b5d