### PR TITLE
Add canvas bouncing ball demo

### DIFF
--- a/wasm/bouncing-ball.html
+++ b/wasm/bouncing-ball.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bouncing Ball Demo</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background-color: #101418;
+      color: #f4f4f4;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      gap: 1.5rem;
+      padding: 2rem 1rem 3rem;
+      background: radial-gradient(circle at top, rgba(255, 255, 255, 0.1), transparent 60%) #101418;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(2rem, 3vw + 1rem, 3rem);
+      text-align: center;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .stage {
+      position: relative;
+      border: 2px solid rgba(255, 255, 255, 0.2);
+      border-radius: 12px;
+      box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.45);
+      overflow: hidden;
+      background: linear-gradient(135deg, #243447, #1c2533);
+    }
+
+    canvas {
+      display: block;
+    }
+
+    #hud {
+      position: absolute;
+      left: 50%;
+      top: 1rem;
+      transform: translateX(-50%);
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      background-color: rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(8px);
+      font-size: 0.95rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    #instructions {
+      text-align: center;
+      font-size: 0.95rem;
+      max-width: 40rem;
+      line-height: 1.6;
+      color: rgba(255, 255, 255, 0.7);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Canvas Bouncing Ball</h1>
+    <p id="instructions">
+      Drag the ball or resize the browser window to see the physics adapt in real time. The frames-per-second counter
+      (FPS) updates every few frames so you can keep an eye on performance.
+    </p>
+    <div class="stage">
+      <canvas id="scene" width="640" height="360" aria-label="Bouncing ball demo"></canvas>
+      <div id="hud">FPS: <span id="fps">0</span></div>
+    </div>
+  </main>
+  <script>
+    const canvas = document.getElementById("scene");
+    const ctx = canvas.getContext("2d");
+    const hud = document.getElementById("hud");
+    const fpsEl = document.getElementById("fps");
+
+    const state = {
+      radius: 28,
+      position: { x: canvas.width * 0.2, y: canvas.height * 0.2 },
+      velocity: { x: 150, y: 75 },
+      gravity: 420,
+      damping: 0.8,
+      drag: 0.0008,
+      lastTime: performance.now(),
+      frameCount: 0,
+      fps: 0,
+      fpsAccumulator: 0,
+    };
+
+    const resizeCanvas = () => {
+      const maxWidth = Math.min(window.innerWidth - 48, 900);
+      const width = Math.max(Math.min(maxWidth, 720), 320);
+      const height = Math.round(width * (9 / 16));
+      const scale = width / canvas.width;
+      const heightScale = height / canvas.height;
+
+      canvas.width = width;
+      canvas.height = height;
+      hud.style.width = `${width}px`;
+
+      state.position.x *= scale;
+      state.position.y *= heightScale;
+      state.radius = Math.max(16, Math.min(36, width / 20));
+    };
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      const gradient = ctx.createRadialGradient(
+        state.position.x,
+        state.position.y,
+        state.radius * 0.35,
+        state.position.x,
+        state.position.y,
+        state.radius
+      );
+      gradient.addColorStop(0, "#ffdf85");
+      gradient.addColorStop(1, "#ff7e5f");
+
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(state.position.x, state.position.y, state.radius, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.strokeStyle = "rgba(255, 255, 255, 0.25)";
+      ctx.lineWidth = 4;
+      ctx.beginPath();
+      ctx.arc(state.position.x, state.position.y, state.radius, Math.PI * 0.15, Math.PI * 0.6);
+      ctx.stroke();
+    };
+
+    const update = (dt) => {
+      const airResistance = 1 - state.drag * dt;
+      state.velocity.x *= airResistance;
+      state.velocity.y = state.velocity.y * airResistance + state.gravity * dt;
+
+      state.position.x += state.velocity.x * dt;
+      state.position.y += state.velocity.y * dt;
+
+      const left = state.radius;
+      const right = canvas.width - state.radius;
+      const top = state.radius;
+      const bottom = canvas.height - state.radius;
+
+      if (state.position.x < left) {
+        state.position.x = left;
+        state.velocity.x *= -state.damping;
+      } else if (state.position.x > right) {
+        state.position.x = right;
+        state.velocity.x *= -state.damping;
+      }
+
+      if (state.position.y < top) {
+        state.position.y = top;
+        state.velocity.y *= -state.damping;
+      } else if (state.position.y > bottom) {
+        state.position.y = bottom;
+        state.velocity.y *= -state.damping;
+      }
+    };
+
+    const step = (time) => {
+      const dt = Math.min((time - state.lastTime) / 1000, 0.1);
+      state.lastTime = time;
+
+      update(dt);
+      draw();
+
+      state.frameCount += 1;
+      state.fpsAccumulator += dt;
+      if (state.fpsAccumulator >= 0.25) {
+        state.fps = Math.round(state.frameCount / state.fpsAccumulator);
+        fpsEl.textContent = state.fps;
+        state.frameCount = 0;
+        state.fpsAccumulator = 0;
+      }
+
+      requestAnimationFrame(step);
+    };
+
+    const pointer = {
+      active: false,
+      offsetX: 0,
+      offsetY: 0,
+    };
+
+    const startDrag = (event) => {
+      const rect = canvas.getBoundingClientRect();
+      const x = (event.clientX || event.touches?.[0]?.clientX) - rect.left;
+      const y = (event.clientY || event.touches?.[0]?.clientY) - rect.top;
+      const dx = x - state.position.x;
+      const dy = y - state.position.y;
+
+      if (dx * dx + dy * dy <= state.radius * state.radius) {
+        pointer.active = true;
+        pointer.offsetX = dx;
+        pointer.offsetY = dy;
+        state.velocity.x = 0;
+        state.velocity.y = 0;
+      }
+    };
+
+    const moveDrag = (event) => {
+      if (!pointer.active) return;
+      const rect = canvas.getBoundingClientRect();
+      const x = (event.clientX || event.touches?.[0]?.clientX) - rect.left;
+      const y = (event.clientY || event.touches?.[0]?.clientY) - rect.top;
+
+      state.position.x = x - pointer.offsetX;
+      state.position.y = y - pointer.offsetY;
+    };
+
+    const endDrag = () => {
+      pointer.active = false;
+    };
+
+    canvas.addEventListener("mousedown", startDrag);
+    canvas.addEventListener("touchstart", startDrag, { passive: true });
+    window.addEventListener("mousemove", moveDrag);
+    window.addEventListener("touchmove", moveDrag, { passive: true });
+    window.addEventListener("mouseup", endDrag);
+    window.addEventListener("touchend", endDrag);
+
+    resizeCanvas();
+    window.addEventListener("resize", resizeCanvas);
+
+    requestAnimationFrame(step);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated bouncing ball demo page under the wasm directory
- render a responsive canvas with draggable ball physics and wall collisions
- display a periodically updating FPS counter overlay

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d511cfa65083328eb771ee1753f78f